### PR TITLE
Meta messages

### DIFF
--- a/iostreams.py
+++ b/iostreams.py
@@ -1,7 +1,8 @@
 from mido import (
     MidiFile,
     MidiTrack,
-    Message
+    Message,
+    midifiles
 )
 import sys
 
@@ -26,9 +27,13 @@ class FileInputStream(FileStream):
         super(FileInputStream, self).__init__(config)
         self.midi_file = MidiFile(self.pathname)
 
+        # The file may contain many tracks. Merge them into a single track,
+        # since the pipeline does not care about tracks.
+        track = midifiles.tracks.merge_tracks(self.midi_file.tracks)
+        self.midi_file.tracks = [track]
+
     def __iter__(self):
-        for message in self.midi_file.play():
-            yield message
+        return iter(self.midi_file.tracks[0])
 
 
 class FileOutputStream(FileStream):

--- a/iostreams.py
+++ b/iostreams.py
@@ -2,7 +2,9 @@ from mido import (
     MidiFile,
     MidiTrack,
     Message,
-    midifiles
+    MetaMessage,
+    midifiles,
+    parse_string
 )
 import sys
 
@@ -50,6 +52,43 @@ class FileOutputStream(FileStream):
         self.output_file.save(self.pathname)
 
 
+def parse_meta_message(body):
+    """ Parse a MetaMessage.
+
+    For example, parse_meta_message("track_name name='Piano left' time=0")
+    returns MetaMessage('track_name', name='Piano left', time=0).
+    """
+    import tokenize, token
+
+    lines = [body]
+    def next_line():
+        if lines:
+            return lines.pop()
+        else:
+            return ''
+    tokens = list(tokenize.generate_tokens(next_line))
+
+    if len(tokens) == 0 or tokens[0][0] != token.NAME:
+        raise ValueError("can't parse meta message type: " + body)
+    message_type = tokens.pop(0)[1]
+
+    kwargs = {}
+    while len(tokens) > 0 and tokens[0][0] != token.ENDMARKER:
+        if len(tokens) < 3:
+            raise ValueError("unexpected end of line {!r}".format(body))
+        if tokens[0][0] != token.NAME:
+            raise ValueError("expected key, got {!r} in line {!r}".format(tokens[0][1], body))
+        if tokens[1][1] != '=':
+            raise ValueError("expected =, got {!r} in line {!r}".format(tokens[1][1], body))
+        if tokens[2][0] not in (token.NUMBER, token.STRING):
+            raise ValueError("expected number or string, got {!r} in line {!r}".format(tokens[2][1], body))
+        name = tokens[0][1]
+        value = eval(tokens[2][1])
+        kwargs[name] = value
+        del tokens[:3]
+    return MetaMessage(message_type, **kwargs)
+
+
 class StdInStream(RequiredConfig):
     required_config = Namespace()
 
@@ -58,17 +97,15 @@ class StdInStream(RequiredConfig):
 
     def __iter__(self):
         for line in sys.stdin:
-            line = line.strip().strip(">")
-            parts = line.split(" ")
-            message_type = parts[1]
-            kwargs = {}
-            for key_value in parts[2:]:
-                key, value = key_value.split("=")
-                if value[-1] == ">":
-                    value = value[:-1]
-                kwargs[key] = int(value)
-            yield Message(message_type, **kwargs)
-
+            line = line.split('#', 1)[0].strip()
+            if line.startswith('<message ') and line.endswith('>'):
+                yield parse_string(line[9:-1])
+            elif line.startswith('<meta message ') and line.endswith('>'):
+                yield parse_meta_message(line[14:-1])
+            elif line == '':
+                pass
+            else:
+                raise ValueError("unrecognized line: " + repr(line))
 
 class StdOutStream(RequiredConfig):
     required_config = Namespace()


### PR DESCRIPTION
The first patch here is doing more than it seems:

* Stop using `.play()`, because it does several undesirable things -- most of all it changes the `.time` attribute of every message from MIDI ticks to seconds -- really bad for virtually any kind of processing, including just round-tripping MIDI -> text -> MIDI.

* On input, merge all MIDI tracks to a single track, so we can iterate over them all without using `.play()`.

* Instead of dropping meta messages, include them in the stream.

The second patch fixes `StdInStream` to cope with meta messages. Complicated code, but I don't know an easier way :-\
